### PR TITLE
Update Chapter14/demo2/demo_server_delete_ctrl.js

### DIFF
--- a/Chapter_14/ansible_demo/root_demo/static/js/angular-controller/demo_2/demo_server_delete_ctrl.js
+++ b/Chapter_14/ansible_demo/root_demo/static/js/angular-controller/demo_2/demo_server_delete_ctrl.js
@@ -24,7 +24,7 @@ app.controller('demo_server_delete_ctrl',function($scope, $http){
     $scope.create_tag = function(tag, ins){
         $scope.operate_type = tag;
         if(tag == 'remove'){
-            $scope.remove_id = ins.id;
+            $scope.id = ins.id;
             $scope.group = ins.group,
             $scope.name = ins.name,
             $scope.ssh_host = ins.ssh_host,


### PR DESCRIPTION
demo2删除运行时报错
Ansible_Host.objects.filter(id=data['remove_id']).delete()
KeyError: 'remove_id'

经检查
此文件第27行的remove_id 应为id。